### PR TITLE
Remove simple-git-hooks on postinstall

### DIFF
--- a/.changeset/shiny-maps-pretend.md
+++ b/.changeset/shiny-maps-pretend.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Run npx simple-git-hooks on postinstall

--- a/.changeset/shiny-maps-pretend.md
+++ b/.changeset/shiny-maps-pretend.md
@@ -2,4 +2,4 @@
 "aws-sdk-js-codemod": patch
 ---
 
-Run npx simple-git-hooks on postinstall
+Remove simple-git-hooks on postinstall

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "build": "tsc",
     "lint": "eslint 'src/*.ts'",
     "release": "yarn build && changeset publish",
-    "test": "jest",
-    "postinstall": "npx simple-git-hooks"
+    "test": "jest"
   },
   "dependencies": {
     "jscodeshift": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint": "eslint 'src/*.ts'",
     "release": "yarn build && changeset publish",
     "test": "jest",
-    "postinstall": "simple-git-hooks"
+    "postinstall": "npx simple-git-hooks"
   },
   "dependencies": {
     "jscodeshift": "0.13.1",


### PR DESCRIPTION
The hooks are needed for local development, and need to be run just once.
The instructions can be added in CONTRIBUTING.md when more developers start contributing to the project.

Existing of this postinstall script is failing installation of `aws-sdk-js-codemod@0.0.2`

```console
$ npm install -g aws-sdk-js-codemod@0.0.2
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: jscodeshift-find-imports@2.0.4
npm WARN Found: jscodeshift@0.13.1
npm WARN node_modules/aws-sdk-js-codemod/node_modules/jscodeshift
npm WARN   jscodeshift@"0.13.1" from aws-sdk-js-codemod@0.0.2
npm WARN   node_modules/aws-sdk-js-codemod
npm WARN     aws-sdk-js-codemod@"0.0.2" from the root project
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer jscodeshift@"^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0" from jscodeshift-find-imports@2.0.4
npm WARN node_modules/aws-sdk-js-codemod/node_modules/jscodeshift-find-imports
npm WARN   jscodeshift-find-imports@"2.0.4" from aws-sdk-js-codemod@0.0.2
npm WARN   node_modules/aws-sdk-js-codemod
npm WARN 
npm WARN Conflicting peer dependency: jscodeshift@0.11.0
npm WARN node_modules/jscodeshift
npm WARN   peer jscodeshift@"^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0" from jscodeshift-find-imports@2.0.4
npm WARN   node_modules/aws-sdk-js-codemod/node_modules/jscodeshift-find-imports
npm WARN     jscodeshift-find-imports@"2.0.4" from aws-sdk-js-codemod@0.0.2
npm WARN     node_modules/aws-sdk-js-codemod
npm WARN deprecated source-map-url@0.4.1: See https://github.com/lydell/source-map-url#deprecated
npm WARN deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
npm WARN deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
npm WARN deprecated source-map-resolve@0.5.3: See https://github.com/lydell/source-map-resolve#deprecated
npm ERR! code 127
npm ERR! path /Users/trivikr/.fnm/node-versions/v16.14.0/installation/lib/node_modules/aws-sdk-js-codemod
npm ERR! command failed
npm ERR! command sh -c simple-git-hooks
npm ERR! sh: simple-git-hooks: command not found

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/trivikr/.npm/_logs/2022-03-02T19_01_34_525Z-debug-0.log
```