### PR TITLE
Limit node-version to 12.x in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Testing in Node.js 14.x and 16.x is not strictly necessary at this stage