### PR TITLE
Use npm exec instead of ./node_modules/.bin

### DIFF
--- a/.changeset/quiet-lizards-run.md
+++ b/.changeset/quiet-lizards-run.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Use npm exec instead of ./node_modules/.bin

--- a/src/__tests__/cli.spec.ts
+++ b/src/__tests__/cli.spec.ts
@@ -8,7 +8,12 @@ import { run } from "../cli";
 jest.mock("child_process");
 
 describe("cli", () => {
-  const jscodeshiftPath = "./node_modules/.bin/jscodeshift";
+  const verifySpawnCall = (args: string[]) => {
+    expect(spawn).toHaveBeenCalledWith("npm", ["exec", "jscodeshift", "--", ...args], {
+      stdio: "inherit",
+      shell: process.platform == "win32",
+    });
+  };
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -23,12 +28,12 @@ describe("cli", () => {
     expect(process.stdout.write).toHaveBeenCalledWith(
       expect.stringMatching(`aws-sdk-js-codemod: ${version}`)
     );
-    expect(spawn).toHaveBeenCalledWith(jscodeshiftPath, mockArgs, { stdio: "inherit" });
+    verifySpawnCall(mockArgs);
   });
 
   it("should pass args to jscodeshift", async () => {
     const mockArgs = ["random", "args", "one", "two", "three"];
     await run(mockArgs);
-    expect(spawn).toHaveBeenCalledWith(jscodeshiftPath, mockArgs, { stdio: "inherit" });
+    verifySpawnCall(mockArgs);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,16 +6,16 @@ import { spawn } from "child_process";
 // @ts-ignore: package.json will be imported from dist folders
 import { version } from "../package.json"; // eslint-disable-line
 
-const [, , ...args] = process.argv;
-const jscodeshiftPath = "./node_modules/.bin/jscodeshift";
-
 export const run = async (args): Promise<void> => {
   if (args[0] === "--version") {
     process.stdout.write(`aws-sdk-js-codemod: ${version}\n\n`);
-    spawn(jscodeshiftPath, ["--version"], { stdio: "inherit" });
-  } else {
-    spawn(jscodeshiftPath, args, { stdio: "inherit" });
   }
+  spawn("npm", ["exec", "jscodeshift", "--", ...args], {
+    stdio: "inherit",
+    shell: process.platform == "win32",
+  });
 };
+
+const [, , ...args] = process.argv;
 
 run(args);


### PR DESCRIPTION
aws-sdk-js-codemod throws `ENOENT` error:

```console
$ aws-sdk-js-codemod --version
aws-sdk-js-codemod: 0.0.4

node:events:498
      throw er; // Unhandled 'error' event
      ^

Error: spawn ./node_modules/.bin/jscodeshift ENOENT
    at Process.ChildProcess._handle.onexit (node:internal/child_process:283:19)
    at onErrorNT (node:internal/child_process:478:16)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
Emitted 'error' event on ChildProcess instance at:
    at Process.ChildProcess._handle.onexit (node:internal/child_process:289:12)
    at onErrorNT (node:internal/child_process:478:16)
    at processTicksAndRejections (node:internal/process/task_queues:83:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'spawn ./node_modules/.bin/jscodeshift',
  path: './node_modules/.bin/jscodeshift',
  spawnargs: [ '--version' ]
}
```

Tested by editing the cli.js file, and verified that this fix works.