### PR TITLE
Skip *.spec.ts files in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
     "resolveJsonModule": true,
     "rootDir": "src"
   },
-  "exclude": ["**/dist/**", "**/__fixtures__/**"]
+  "exclude": ["**/__fixtures__/**", "**/*.spec.ts"]
 }


### PR DESCRIPTION
The `*.spec.ts` files need to be skipped as they're no longer in `__tests__` folder.

Follow-up to:
* https://github.com/trivikr/aws-sdk-js-codemod/pull/25
* https://github.com/trivikr/aws-sdk-js-codemod/pull/27