### PR TITLE
Check for source 'aws-sdk' while removing default imports

### DIFF
--- a/.changeset/calm-toys-destroy.md
+++ b/.changeset/calm-toys-destroy.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Check for source 'aws-sdk' while removing default imports

--- a/src/transforms/v2-to-v3/utils/removeDefaultImportIfNotUsed.ts
+++ b/src/transforms/v2-to-v3/utils/removeDefaultImportIfNotUsed.ts
@@ -14,6 +14,7 @@ export const removeDefaultImportIfNotUsed = (
     source
       .find(j.ImportDeclaration, {
         specifiers: [{ type: "ImportDefaultSpecifier", local: { name: defaultImportName } }],
+        source: { value: "aws-sdk" },
       })
       .forEach((declerationPath) => {
         // Remove default import from ImportDecleration.


### PR DESCRIPTION
This bug was noticed while working on https://github.com/trivikr/aws-sdk-js-codemod/issues/49