### PR TITLE
Explicitly pass parser=ts in transformer tests

### DIFF
--- a/.changeset/bright-penguins-pump.md
+++ b/.changeset/bright-penguins-pump.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Explicitly pass parser=ts in transformer tests

--- a/src/transforms/v2-to-v3/transformer.spec.ts
+++ b/src/transforms/v2-to-v3/transformer.spec.ts
@@ -15,6 +15,6 @@ describe("v2-to-v3", () => {
     const source = readFileSync(path, "utf8");
     const input = { path, source };
     const expectedOutput = readFileSync(join(fixtureDir, testFilePrefix + `.output.ts`), "utf8");
-    runInlineTest(transformer, null, input, expectedOutput);
+    runInlineTest(transformer, null, input, expectedOutput, { parser: "ts" });
   });
 });


### PR DESCRIPTION
Refs: https://github.com/reactjs/react-codemod/issues/207#issuecomment-942256980

This was noticed when the test in https://github.com/trivikr/aws-sdk-js-codemod/pull/77 was failing with:
```console
SyntaxError: Unexpected token, expected "," (3:33)

      at Object._raise (node_modules/@babel/parser/src/parser/error.js:150:45)
      at Object.raiseWithData (node_modules/@babel/parser/src/parser/error.js:[14](https://github.com/trivikr/aws-sdk-js-codemod/runs/5474511976?check_suite_focus=true#step:7:14)5:17)
      at Object.raise (node_modules/@babel/parser/src/parser/error.js:89:17)
```

We expected test to fail with:
```console
- import { DynamoDB } from "@aws-sdk/client-dynamodb";
    + import AWS from "aws-sdk";

    - export const listTables = (client: DynamoDB) => client.listTables();
    + export const listTables = (client: AWS.DynamoDB) => client.listTables().promise();
```