### PR TITLE
Move testOptions inside testFilePrefix in transformer tests

### DIFF
--- a/src/transforms/v2-to-v3/transformer.spec.ts
+++ b/src/transforms/v2-to-v3/transformer.spec.ts
@@ -10,8 +10,8 @@ describe("v2-to-v3", () => {
     .filter((fileName) => fileName.endsWith(".input.ts"))
     .map((fileName) => fileName.replace(".input.ts", ""));
 
-  describe.each([{}, { parser: "ts" }])("testOptions: %o", (testOptions) => {
-    it.each(testFilePrefixes)(`transforms correctly using "%s" data`, (testFilePrefix) => {
+  describe.each(testFilePrefixes)(`transforms correctly using "%s" data`, (testFilePrefix) => {
+    it.each([{}, { parser: "ts" }])("with testOptions: %o", (testOptions) => {
       const path = join(fixtureDir, testFilePrefix + `.input.ts`);
       const source = readFileSync(path, "utf8");
       const input = { path, source };


### PR DESCRIPTION
Reasons for the move:
* Slightly faster. Takes 34s instead of 36s.
* The `testFilePrefixes` variable can be replaced with specific filename being tested.
* The testOptions array can be modified based on file name. For example, due to bug https://github.com/facebook/jscodeshift/issues/488, some tests will be specific to `parser=ts` in future