### PR TITLE
Read input/output code outside test section

### DIFF
--- a/src/transforms/v2-to-v3/transformer.spec.ts
+++ b/src/transforms/v2-to-v3/transformer.spec.ts
@@ -11,12 +11,14 @@ describe("v2-to-v3", () => {
     .map((fileName) => fileName.replace(".input.ts", ""));
 
   describe.each(testFilePrefixes)(`transforms correctly using "%s" data`, (testFilePrefix) => {
+    const inputPath = join(fixtureDir, testFilePrefix + `.input.ts`);
+    const outputPath = join(fixtureDir, testFilePrefix + `.output.ts`);
+    const inputCode = readFileSync(inputPath, "utf8");
+    const outputCode = readFileSync(outputPath, "utf8");
+    const input = { path: inputPath, source: inputCode };
+
     it.each([{}, { parser: "ts" }])("with testOptions: %o", (testOptions) => {
-      const path = join(fixtureDir, testFilePrefix + `.input.ts`);
-      const source = readFileSync(path, "utf8");
-      const input = { path, source };
-      const expectedOutput = readFileSync(join(fixtureDir, testFilePrefix + `.output.ts`), "utf8");
-      runInlineTest(transformer, null, input, expectedOutput, testOptions);
+      runInlineTest(transformer, null, input, outputCode, testOptions);
     });
   });
 });


### PR DESCRIPTION
No significant improvement in time taken to run tests, but it's better organization of test code.