### PR TITLE
Run yarn lint on all source files

### DIFF
--- a/.changeset/bright-fishes-film.md
+++ b/.changeset/bright-fishes-film.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Run yarn lint on all source files

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "lint": "eslint 'src/*.ts'",
+    "lint": "eslint 'src/**/*.ts'",
     "release": "yarn build && changeset publish",
     "test": "jest"
   },


### PR DESCRIPTION
Right now, the linter was being run only on TypeScript files in parent `src` folder.