### PR TITLE
Enable eslint naming-convention rule

### DIFF
--- a/.changeset/small-beds-lay.md
+++ b/.changeset/small-beds-lay.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Enable eslint naming-convention rule with camelCase, UPPER_CASE and PascalCase

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,15 @@
   "rules": {
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error",
-    "@typescript-eslint/array-type": ["error", { "default": "array" }]
+    "@typescript-eslint/array-type": ["error", { "default": "array" }],
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        "selector": "default",
+        "format": ["camelCase", "UPPER_CASE", "PascalCase"],
+        "leadingUnderscore": "allow"
+      }
+    ]
   },
   "ignorePatterns": ["__fixtures__"]
 }


### PR DESCRIPTION
Enable eslint naming-convention rule with camelCase, UPPER_CASE and PascalCase

Docs: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/naming-convention.md