### PR TITLE
Replace <any> with <unknown>

### DIFF
--- a/.changeset/cuddly-shrimps-wait.md
+++ b/.changeset/cuddly-shrimps-wait.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-js-codemod": patch
+---
+
+Replace <any> with <unknown>

--- a/src/transforms/v2-to-v3/utils/addV3ClientImport.ts
+++ b/src/transforms/v2-to-v3/utils/addV3ClientImport.ts
@@ -6,7 +6,7 @@ import { getV2ClientModulePath } from "./getV2ClientModulePath";
 
 export const addV3ClientImport = (
   j: JSCodeshift,
-  source: Collection<any>,
+  source: Collection<unknown>,
   { v2ClientName, v3ClientName, v3ClientPackageName }: AddV3ClientModuleOptions
 ): void => {
   const existingImports = source.find(j.ImportDeclaration, {

--- a/src/transforms/v2-to-v3/utils/addV3ClientModule.ts
+++ b/src/transforms/v2-to-v3/utils/addV3ClientModule.ts
@@ -12,7 +12,7 @@ export interface AddV3ClientModuleOptions {
 
 export const addV3ClientModule = (
   j: JSCodeshift,
-  source: Collection<any>,
+  source: Collection<unknown>,
   { v2ClientName, v3ClientName, v3ClientPackageName }: AddV3ClientModuleOptions
 ): void =>
   containsRequire(j, source)

--- a/src/transforms/v2-to-v3/utils/addV3ClientRequire.ts
+++ b/src/transforms/v2-to-v3/utils/addV3ClientRequire.ts
@@ -7,7 +7,7 @@ import { getV2ClientModulePath } from "./getV2ClientModulePath";
 
 export const addV3ClientRequire = (
   j: JSCodeshift,
-  source: Collection<any>,
+  source: Collection<unknown>,
   { v2ClientName, v3ClientName, v3ClientPackageName }: AddV3ClientModuleOptions
 ): void => {
   const v3ClientNameIdentifier = j.identifier(v3ClientName);

--- a/src/transforms/v2-to-v3/utils/containsRequire.ts
+++ b/src/transforms/v2-to-v3/utils/containsRequire.ts
@@ -1,6 +1,6 @@
 import { Collection, JSCodeshift } from "jscodeshift";
 
-export const containsRequire = (j: JSCodeshift, source: Collection<any>) =>
+export const containsRequire = (j: JSCodeshift, source: Collection<unknown>) =>
   source
     .find(j.CallExpression, {
       callee: { type: "Identifier", name: "require" },

--- a/src/transforms/v2-to-v3/utils/getImportIdentifierName.ts
+++ b/src/transforms/v2-to-v3/utils/getImportIdentifierName.ts
@@ -2,7 +2,7 @@ import { Collection, JSCodeshift } from "jscodeshift";
 
 export const getImportIdentifierName = (
   j: JSCodeshift,
-  source: Collection<any>,
+  source: Collection<unknown>,
   literalValue: string
 ): string | undefined =>
   source

--- a/src/transforms/v2-to-v3/utils/getRequireIdentifierName.ts
+++ b/src/transforms/v2-to-v3/utils/getRequireIdentifierName.ts
@@ -2,7 +2,7 @@ import { Collection, Identifier, JSCodeshift } from "jscodeshift";
 
 export const getRequireIdentifierName = (
   j: JSCodeshift,
-  source: Collection<any>,
+  source: Collection<unknown>,
   literalValue: string
 ): string | undefined =>
   (

--- a/src/transforms/v2-to-v3/utils/getRequireVariableDeclaration.ts
+++ b/src/transforms/v2-to-v3/utils/getRequireVariableDeclaration.ts
@@ -2,7 +2,7 @@ import { Collection, JSCodeshift } from "jscodeshift";
 
 export const getRequireVariableDeclaration = (
   j: JSCodeshift,
-  source: Collection<any>,
+  source: Collection<unknown>,
   literalValue: string
 ) =>
   source.find(j.VariableDeclaration, {

--- a/src/transforms/v2-to-v3/utils/getV2ClientModuleNames.ts
+++ b/src/transforms/v2-to-v3/utils/getV2ClientModuleNames.ts
@@ -6,7 +6,7 @@ import { getImportIdentifierName } from "./getImportIdentifierName";
 import { getRequireIdentifierName } from "./getRequireIdentifierName";
 import { getV2ClientModulePath } from "./getV2ClientModulePath";
 
-export const getV2ClientModuleNames = (j: JSCodeshift, source: Collection<any>): string[] =>
+export const getV2ClientModuleNames = (j: JSCodeshift, source: Collection<unknown>): string[] =>
   CLIENT_NAMES.map((clientName) =>
     containsRequire(j, source)
       ? getRequireIdentifierName(j, source, getV2ClientModulePath(clientName))

--- a/src/transforms/v2-to-v3/utils/getV2ClientNames.ts
+++ b/src/transforms/v2-to-v3/utils/getV2ClientNames.ts
@@ -9,7 +9,7 @@ export interface GetV2ClientNamesOptions {
 
 export const getV2ClientNames = (
   j: JSCodeshift,
-  source: Collection<any>,
+  source: Collection<unknown>,
   { v2DefaultModuleName, v2ClientModuleNames }: GetV2ClientNamesOptions
 ): string[] => {
   const v2ClientNamesFromDefaultModule = source

--- a/src/transforms/v2-to-v3/utils/getV2DefaultModuleName.ts
+++ b/src/transforms/v2-to-v3/utils/getV2DefaultModuleName.ts
@@ -7,7 +7,7 @@ import { getRequireIdentifierName } from "./getRequireIdentifierName";
 
 export const getV2DefaultModuleName = (
   j: JSCodeshift,
-  source: Collection<any>
+  source: Collection<unknown>
 ): string | undefined =>
   containsRequire(j, source)
     ? getRequireIdentifierName(j, source, PACKAGE_NAME)

--- a/src/transforms/v2-to-v3/utils/removeDefaultModuleIfNotUsed.ts
+++ b/src/transforms/v2-to-v3/utils/removeDefaultModuleIfNotUsed.ts
@@ -7,7 +7,7 @@ import { removeRequireIdentifierName } from "./removeRequireIdentifierName";
 
 export const removeDefaultModuleIfNotUsed = (
   j: JSCodeshift,
-  source: Collection<any>,
+  source: Collection<unknown>,
   defaultModuleName: string
 ) => {
   const identifierUsages = source.find(j.Identifier, { name: defaultModuleName });

--- a/src/transforms/v2-to-v3/utils/removeImportIdentifierName.ts
+++ b/src/transforms/v2-to-v3/utils/removeImportIdentifierName.ts
@@ -7,7 +7,7 @@ export interface RemoveImportIdentifierNameOptions {
 
 export const removeImportIdentifierName = (
   j: JSCodeshift,
-  source: Collection<any>,
+  source: Collection<unknown>,
   { identifierName, literalValue }: RemoveImportIdentifierNameOptions
 ) => {
   source

--- a/src/transforms/v2-to-v3/utils/removePromiseCalls.ts
+++ b/src/transforms/v2-to-v3/utils/removePromiseCalls.ts
@@ -8,7 +8,7 @@ export interface RemovePromiseCallsOptions {
 // Removes .promise() from client API calls.
 export const removePromiseCalls = (
   j: JSCodeshift,
-  source: Collection<any>,
+  source: Collection<unknown>,
   { v2DefaultModuleName, v2ClientName }: RemovePromiseCallsOptions
 ): void => {
   source

--- a/src/transforms/v2-to-v3/utils/removeRequireIdentifierName.ts
+++ b/src/transforms/v2-to-v3/utils/removeRequireIdentifierName.ts
@@ -9,7 +9,7 @@ export interface RemoveRequireIdentifierNameOptions {
 
 export const removeRequireIdentifierName = (
   j: JSCodeshift,
-  source: Collection<any>,
+  source: Collection<unknown>,
   { identifierName, literalValue }: RemoveRequireIdentifierNameOptions
 ) => {
   getRequireVariableDeclaration(j, source, literalValue)

--- a/src/transforms/v2-to-v3/utils/removeV2ClientModule.ts
+++ b/src/transforms/v2-to-v3/utils/removeV2ClientModule.ts
@@ -7,7 +7,7 @@ import { removeRequireIdentifierName } from "./removeRequireIdentifierName";
 
 export const removeV2ClientModule = (
   j: JSCodeshift,
-  source: Collection<any>,
+  source: Collection<unknown>,
   v2ClientName: string
 ) => {
   const removeIdentifierNameOptions = {

--- a/src/transforms/v2-to-v3/utils/replaceClientCreation.ts
+++ b/src/transforms/v2-to-v3/utils/replaceClientCreation.ts
@@ -9,7 +9,7 @@ export interface ReplaceClientCreationOptions {
 // Replace v2 client creation with v3 client creation.
 export const replaceClientCreation = (
   j: JSCodeshift,
-  source: Collection<any>,
+  source: Collection<unknown>,
   { v2DefaultModuleName, v2ClientName, v3ClientName }: ReplaceClientCreationOptions
 ): void => {
   // Replace clients created with default module.


### PR DESCRIPTION
Usage of `<any>` shows warnings in ESLint under rule `@typescript-eslint/no-explicit-any`:

```console
/home/runner/work/aws-sdk-js-codemod/aws-sdk-js-codemod/src/transforms/v2-to-v3/utils/addV3ClientImport.ts
Warning:   9:22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/runner/work/aws-sdk-js-codemod/aws-sdk-js-codemod/src/transforms/v2-to-v3/utils/addV3ClientModule.ts
Warning:   15:22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/runner/work/aws-sdk-js-codemod/aws-sdk-js-codemod/src/transforms/v2-to-v3/utils/addV3ClientRequire.ts
Warning:   10:22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/runner/work/aws-sdk-js-codemod/aws-sdk-js-codemod/src/transforms/v2-to-v3/utils/containsRequire.ts
Warning:   3:[6](https://github.com/trivikr/aws-sdk-js-codemod/runs/5488178213?check_suite_focus=true#step:6:6)8  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/runner/work/aws-sdk-js-codemod/aws-sdk-js-codemod/src/transforms/v2-to-v3/utils/getImportIdentifierName.ts
Warning:   5:22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/runner/work/aws-sdk-js-codemod/aws-sdk-js-codemod/src/transforms/v2-to-v3/utils/getRequireIdentifierName.ts
Warning:   5:22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/runner/work/aws-sdk-js-codemod/aws-sdk-js-codemod/src/transforms/v2-to-v3/utils/getRequireVariableDeclaration.ts
Warning:   5:22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/runner/work/aws-sdk-js-codemod/aws-sdk-js-codemod/src/transforms/v2-to-v3/utils/getV2ClientModuleNames.ts
Warning:   9:[7](https://github.com/trivikr/aws-sdk-js-codemod/runs/5488178213?check_suite_focus=true#step:6:7)5  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/runner/work/aws-sdk-js-codemod/aws-sdk-js-codemod/src/transforms/v2-to-v3/utils/getV2ClientNames.ts
Warning:   12:22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/runner/work/aws-sdk-js-codemod/aws-sdk-js-codemod/src/transforms/v2-to-v3/utils/getV2DefaultModuleName.ts
Warning:   [10](https://github.com/trivikr/aws-sdk-js-codemod/runs/5488178213?check_suite_focus=true#step:6:10):22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/runner/work/aws-sdk-js-codemod/aws-sdk-js-codemod/src/transforms/v2-to-v3/utils/removeDefaultModuleIfNotUsed.ts
Warning:   10:22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/runner/work/aws-sdk-js-codemod/aws-sdk-js-codemod/src/transforms/v2-to-v3/utils/removeImportIdentifierName.ts
Warning:   10:22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/runner/work/aws-sdk-js-codemod/aws-sdk-js-codemod/src/transforms/v2-to-v3/utils/removePromiseCalls.ts
Warning:   [11](https://github.com/trivikr/aws-sdk-js-codemod/runs/5488178213?check_suite_focus=true#step:6:11):22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/runner/work/aws-sdk-js-codemod/aws-sdk-js-codemod/src/transforms/v2-to-v3/utils/removeRequireIdentifierName.ts
Warning:   [12](https://github.com/trivikr/aws-sdk-js-codemod/runs/5488178213?check_suite_focus=true#step:6:12):22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/runner/work/aws-sdk-js-codemod/aws-sdk-js-codemod/src/transforms/v2-to-v3/utils/removeV2ClientModule.ts
Warning:   10:22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/runner/work/aws-sdk-js-codemod/aws-sdk-js-codemod/src/transforms/v2-to-v3/utils/replaceClientCreation.ts
Warning:   12:22  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

✖ [16](https://github.com/trivikr/aws-sdk-js-codemod/runs/5488178213?check_suite_focus=true#step:6:16) problems (0 errors, 16 warnings)
```

GitHub Actions also show check annotations from running lint, even if file is not touched.
Example https://github.com/trivikr/aws-sdk-js-codemod/pull/97